### PR TITLE
Fix block_stream return type

### DIFF
--- a/src/tree/block_scanner.rs
+++ b/src/tree/block_scanner.rs
@@ -60,7 +60,7 @@ where
 
     pub fn block_stream(
         &self,
-    ) -> impl Stream<Item: Future<Output = WorldTreeResult<Vec<Log>>> + Send> + '_
+    ) -> impl Stream<Item = impl Future<Output = WorldTreeResult<Vec<Log>>> + Send> + '_
     {
         stream::unfold(
             (self.start_block, 0),


### PR DESCRIPTION
## Summary
- fix the return type of `block_stream`

## Testing
- `cargo test --locked --no-default-features` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_e_685132796e94832c9511b131b756ad9f